### PR TITLE
Feat/up9.0

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET SDK 6.0.x
+    - name: Setup .NET SDK 9.0.x
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 6.0.x 
+        dotnet-version: 9.0.x 
     
     - name: Show dotnet Version
       run: |
@@ -30,7 +30,3 @@ jobs:
     - name: Build with dotnet      
       run: |
         dotnet build img-go.sln
-
-#    - name: Run tests on net6.0
-#      run: |
-#        dotnet test tests/RDBParserTests/RDBParserTests.csproj

--- a/.github/workflows/release_stable_cli.yaml
+++ b/.github/workflows/release_stable_cli.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Set up .NET Core
           uses: actions/setup-dotnet@v2
           with:
-              dotnet-version: "6.x"
+              dotnet-version: "9.x"
         - name: Publish .NET app
           env:
               VERSION: ${{ github.ref_name }}
@@ -59,7 +59,7 @@ jobs:
         - name: Set up .NET Core
           uses: actions/setup-dotnet@v2
           with:
-              dotnet-version: "6.x"
+              dotnet-version: "9.x"
         - name: Publish .NET app
           env:
               RID: ${{ matrix.targets }}

--- a/.github/workflows/release_stable_nuget.yaml
+++ b/.github/workflows/release_stable_nuget.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 9.0.x
 
     - name: Build with dotnet
       env:

--- a/.github/workflows/release_unstable_cli.yaml
+++ b/.github/workflows/release_unstable_cli.yaml
@@ -16,7 +16,7 @@ jobs:
         - name: Set up .NET Core
           uses: actions/setup-dotnet@v2
           with:
-              dotnet-version: "6.x"
+              dotnet-version: "9.x"
         - name: Publish .NET app
           env:
               VERSION: ${{ github.ref_name }}
@@ -58,7 +58,7 @@ jobs:
         - name: Set up .NET Core
           uses: actions/setup-dotnet@v2
           with:
-              dotnet-version: "6.x"
+              dotnet-version: "9.x"
         - name: Publish .NET app
           env:
               RID: ${{ matrix.targets }}

--- a/.github/workflows/release_unstable_nuget.yaml
+++ b/.github/workflows/release_unstable_nuget.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.x
+        dotnet-version: 9.x
 
     - name: Build with dotnet
       env:

--- a/src/ImgGoCli/ImgGoCli.csproj
+++ b/src/ImgGoCli/ImgGoCli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>img-go</AssemblyName>
@@ -37,16 +37,16 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.14.1" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Qiniu" Version="8.2.0" />
+      <PackageReference Include="Qiniu" Version="8.7.0" />
       <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
       <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-      <PackageReference Include="Tencent.QCloud.Cos.Sdk" Version="5.4.32" />
+      <PackageReference Include="Tencent.QCloud.Cos.Sdk" Version="5.4.44" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes several updates to the .NET SDK version and package references across multiple workflow files and project files. The most important changes include updating the .NET SDK version from 6.x to 9.x, and updating various package references in the `ImgGoCli.csproj` file.

### Updates to .NET SDK version:

* [`.github/workflows/build_and_test.yaml`](diffhunk://#diff-868425f4c6dd9927d83974d334ea46b9ec96854cdac9bb15b15f43bc4ad17820L20-R23): Updated .NET SDK version from 6.x to 9.x.
* [`.github/workflows/release_stable_cli.yaml`](diffhunk://#diff-609c66b1dc058f9d3ff6acc45ac68e8cebde8250f3b11083f7ad41c90c2f5440L20-R20): Updated .NET SDK version from 6.x to 9.x [[1]](diffhunk://#diff-609c66b1dc058f9d3ff6acc45ac68e8cebde8250f3b11083f7ad41c90c2f5440L20-R20) [[2]](diffhunk://#diff-609c66b1dc058f9d3ff6acc45ac68e8cebde8250f3b11083f7ad41c90c2f5440L62-R62).
* [`.github/workflows/release_stable_nuget.yaml`](diffhunk://#diff-d708351bce2cae1e92ea7caa95a12c37f37bebee2018cc8a70113ff6bb3f1b8dL20-R20): Updated .NET SDK version from 6.x to 9.x.
* [`.github/workflows/release_unstable_cli.yaml`](diffhunk://#diff-a74bff7290d5518a52022ad13f5c27b1933bcc2b2c77e972a32b250db13e00b8L19-R19): Updated .NET SDK version from 6.x to 9.x [[1]](diffhunk://#diff-a74bff7290d5518a52022ad13f5c27b1933bcc2b2c77e972a32b250db13e00b8L19-R19) [[2]](diffhunk://#diff-a74bff7290d5518a52022ad13f5c27b1933bcc2b2c77e972a32b250db13e00b8L61-R61).
* [`.github/workflows/release_unstable_nuget.yaml`](diffhunk://#diff-4a2bccbc03c0e7065af7806002481798ca7ecd3286a0e4f13f718d4e45a344b5L19-R19): Updated .NET SDK version from 6.x to 9.x.

### Updates to package references:

* `src/ImgGoCli/ImgGoCli.csproj`: Updated `TargetFramework` from net6.0 to net9.0 and various package versions:
  * `Aliyun.OSS.SDK.NetCore` from 2.13.0 to 2.14.1
  * `Microsoft.SourceLink.GitHub` from 1.1.1 to 8.0.0
  * `Qiniu` from 8.2.0 to 8.7.0
  * `Tencent.QCloud.Cos.Sdk` from 5.4.32 to 5.4.44 [[1]](diffhunk://#diff-d3a3681fd7a496263ef7e58822b3ed81fceb157fd8b367508c2e1dba19852985L5-R5) [[2]](diffhunk://#diff-d3a3681fd7a496263ef7e58822b3ed81fceb157fd8b367508c2e1dba19852985L40-R49).